### PR TITLE
dropping previous table

### DIFF
--- a/db/migrate/20230211220034_add_receipt_id.rb
+++ b/db/migrate/20230211220034_add_receipt_id.rb
@@ -1,4 +1,5 @@
 class AddReceiptId < ActiveRecord::Migration[7.0]
   def change
+    drop_table :receipts
   end
 end


### PR DESCRIPTION
should drop the previous receipt table, this migration should be deleted in the future after this has been released to production as this is a one time thing for the fix